### PR TITLE
push削除

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: test
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   Test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR作成時に同じjobが複数走ってしまうので`push`の指定を削除しました。